### PR TITLE
Add fragment publishing flows to Expo client

### DIFF
--- a/mused-rn/app/(tabs)/_layout.tsx
+++ b/mused-rn/app/(tabs)/_layout.tsx
@@ -24,6 +24,15 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="create"
+        options={{
+          title: 'Create',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="plus.rectangle.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="explore"
         options={{
           title: 'Explore',

--- a/mused-rn/app/(tabs)/create.tsx
+++ b/mused-rn/app/(tabs)/create.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useState } from 'react';
+import { ActivityIndicator, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import FragmentEditor from '@/components/fragments/fragment-editor';
+
+export default function CreateFragmentScreen() {
+  const [isPosting, setIsPosting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const handlePostStart = useCallback(() => {
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsPosting(true);
+  }, []);
+
+  const handlePostSuccess = useCallback(() => {
+    setIsPosting(false);
+    setSuccessMessage('Fragment posted successfully!');
+  }, []);
+
+  const handlePostError = useCallback((error: Error) => {
+    setIsPosting(false);
+    setErrorMessage(error.message);
+  }, []);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.pageTitle}>Create a fragment</Text>
+        <Text style={styles.pageSubtitle}>
+          Build your beat, add a title, and share it with the Mused community.
+        </Text>
+
+        <FragmentEditor
+          onPostStart={handlePostStart}
+          onPostSuccess={handlePostSuccess}
+          onPostError={handlePostError}
+        />
+
+        {isPosting ? (
+          <View style={styles.statusRow}>
+            <ActivityIndicator color="#111827" size="small" />
+            <Text style={styles.statusLabel}>Publishing your fragment…</Text>
+          </View>
+        ) : null}
+
+        {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
+        {successMessage ? <Text style={styles.successText}>{successMessage}</Text> : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  content: {
+    padding: 24,
+    gap: 24,
+  },
+  pageTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+  },
+  pageSubtitle: {
+    fontSize: 16,
+    lineHeight: 22,
+    color: '#6b7280',
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  statusLabel: {
+    fontSize: 14,
+    color: '#111827',
+  },
+  errorText: {
+    color: '#dc2626',
+    fontSize: 14,
+  },
+  successText: {
+    color: '#047857',
+    fontSize: 14,
+  },
+});

--- a/mused-rn/app/_layout.tsx
+++ b/mused-rn/app/_layout.tsx
@@ -17,6 +17,12 @@ export default function RootLayout() {
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+        <Stack.Screen
+          name="remix/[fragmentId]"
+          options={{
+            title: 'Remix fragment',
+          }}
+        />
       </Stack>
       <StatusBar style="auto" />
     </ThemeProvider>

--- a/mused-rn/app/lib/firebase.ts
+++ b/mused-rn/app/lib/firebase.ts
@@ -14,7 +14,7 @@ const firebaseConfig = {
 // Initialize Firebase
 if (!getApps().length) {
   // Prevents initializing Firebase multiple times
-  const app = initializeApp(firebaseConfig);
+  initializeApp(firebaseConfig);
 }
-const app = getApp();
-export { app };
+
+export const app = getApp();

--- a/mused-rn/app/remix/[fragmentId].tsx
+++ b/mused-rn/app/remix/[fragmentId].tsx
@@ -29,6 +29,7 @@ export default function RemixFragmentScreen() {
   const [initialBpm, setInitialBpm] = useState<number>(120);
   const [initialTitle, setInitialTitle] = useState<string>('');
   const [originalAuthor, setOriginalAuthor] = useState<string | null>(null);
+  const [originalAuthorId, setOriginalAuthorId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -105,6 +106,13 @@ export default function RemixFragmentScreen() {
         setInitialBpm(typeof data.bpm === 'number' ? data.bpm : 120);
         setInitialTitle(data.title ? `Remix of ${data.title}` : 'Remix');
         setOriginalAuthor(data.originalAuthor ?? data.author ?? null);
+        setOriginalAuthorId(
+          typeof data.originalAuthorId === 'string'
+            ? data.originalAuthorId
+            : typeof (data as any)?.original_author_id === 'string'
+            ? ((data as any).original_author_id as string)
+            : null,
+        );
         setLoadError(null);
       } catch (error) {
         if (!isMounted) {
@@ -174,6 +182,7 @@ export default function RemixFragmentScreen() {
             initialTitle={initialTitle}
             originalFragmentId={typeof fragmentId === 'string' ? fragmentId : null}
             originalAuthorName={originalAuthor}
+            originalAuthorId={originalAuthorId}
             onPostStart={handlePostStart}
             onPostSuccess={handlePostSuccess}
             onPostError={handlePostError}

--- a/mused-rn/app/remix/[fragmentId].tsx
+++ b/mused-rn/app/remix/[fragmentId].tsx
@@ -1,0 +1,236 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+import FragmentEditor from '@/components/fragments/fragment-editor';
+import type { Pad } from '@/lib/types';
+
+type RemotePad = Partial<Pad> & {
+  id?: number;
+  sounds?: Partial<Pad['sounds'][number]>[];
+};
+
+type RemoteFragment = {
+  pads?: RemotePad[];
+  bpm?: number;
+  title?: string;
+  author?: string;
+  originalAuthor?: string;
+  originalAuthorId?: string;
+};
+
+const getApiUrl = () =>
+  process.env.EXPO_PUBLIC_MUSED_API_URL ?? process.env.NEXT_PUBLIC_MUSED_API_URL;
+
+export default function RemixFragmentScreen() {
+  const { fragmentId } = useLocalSearchParams<{ fragmentId?: string }>();
+
+  const [initialPads, setInitialPads] = useState<Pad[] | null>(null);
+  const [initialBpm, setInitialBpm] = useState<number>(120);
+  const [initialTitle, setInitialTitle] = useState<string>('');
+  const [originalAuthor, setOriginalAuthor] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [isPosting, setIsPosting] = useState(false);
+  const [postError, setPostError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!fragmentId || typeof fragmentId !== 'string') {
+      setLoadError('Fragment not found.');
+      setIsLoading(false);
+      return;
+    }
+
+    const apiUrl = getApiUrl();
+    if (!apiUrl) {
+      setLoadError('API URL is not configured. Set EXPO_PUBLIC_MUSED_API_URL in your app config.');
+      setIsLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchFragment = async () => {
+      try {
+        const response = await fetch(`${apiUrl}/fragments/${fragmentId}`);
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          const message =
+            (payload && (payload.error || payload.details)) ||
+            `Unable to load fragment (status ${response.status}).`;
+          throw new Error(message);
+        }
+
+        const data: RemoteFragment = await response.json();
+
+        if (!isMounted) {
+          return;
+        }
+
+        const padsFromApi = (data.pads ?? []).map<Pad>((pad, padIndex) => ({
+          id: typeof pad.id === 'number' ? pad.id : padIndex,
+          isActive:
+            typeof pad.isActive === 'boolean'
+              ? pad.isActive
+              : (pad.sounds && pad.sounds.length ? pad.sounds.length > 0 : false),
+          currentSoundIndex:
+            typeof pad.currentSoundIndex === 'number' ? pad.currentSoundIndex : 0,
+          sounds: (pad.sounds ?? []).map((sound, soundIndex) => ({
+            soundId:
+              typeof sound?.soundId === 'string'
+                ? sound.soundId
+                : typeof (sound as any)?.id === 'string'
+                ? ((sound as any).id as string)
+                : `${padIndex}-${soundIndex}`,
+            soundName:
+              typeof sound?.soundName === 'string'
+                ? sound.soundName
+                : typeof (sound as any)?.name === 'string'
+                ? ((sound as any).name as string)
+                : 'Untitled sound',
+            soundUrl:
+              typeof sound?.soundUrl === 'string'
+                ? sound.soundUrl
+                : typeof (sound as any)?.downloadUrl === 'string'
+                ? ((sound as any).downloadUrl as string)
+                : typeof (sound as any)?.source_url === 'string'
+                ? ((sound as any).source_url as string)
+                : undefined,
+          })),
+        }));
+
+        setInitialPads(padsFromApi);
+        setInitialBpm(typeof data.bpm === 'number' ? data.bpm : 120);
+        setInitialTitle(data.title ? `Remix of ${data.title}` : 'Remix');
+        setOriginalAuthor(data.originalAuthor ?? data.author ?? null);
+        setLoadError(null);
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+        const message =
+          error instanceof Error ? error.message : 'Something went wrong loading the fragment.';
+        setLoadError(message);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchFragment();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [fragmentId]);
+
+  const handlePostStart = useCallback(() => {
+    setIsPosting(true);
+    setPostError(null);
+    setSuccessMessage(null);
+  }, []);
+
+  const handlePostSuccess = useCallback(() => {
+    setIsPosting(false);
+    setSuccessMessage('Remix posted successfully!');
+  }, []);
+
+  const handlePostError = useCallback((error: Error) => {
+    setIsPosting(false);
+    setPostError(error.message);
+  }, []);
+
+  const screenTitle = useMemo(() => {
+    if (originalAuthor) {
+      return `Remix ${originalAuthor}'s fragment`;
+    }
+    return 'Create a remix';
+  }, [originalAuthor]);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.pageTitle}>{screenTitle}</Text>
+        <Text style={styles.pageSubtitle}>
+          Load the original pads, tweak the arrangement, and submit your take.
+        </Text>
+
+        {isLoading ? (
+          <View style={styles.centeredState}>
+            <ActivityIndicator color="#111827" size="large" />
+            <Text style={styles.statusLabel}>Loading fragment…</Text>
+          </View>
+        ) : null}
+
+        {loadError ? <Text style={styles.errorText}>{loadError}</Text> : null}
+
+        {!isLoading && !loadError ? (
+          <FragmentEditor
+            initialPads={initialPads ?? undefined}
+            initialBpm={initialBpm}
+            initialTitle={initialTitle}
+            originalFragmentId={typeof fragmentId === 'string' ? fragmentId : null}
+            originalAuthorName={originalAuthor}
+            onPostStart={handlePostStart}
+            onPostSuccess={handlePostSuccess}
+            onPostError={handlePostError}
+          />
+        ) : null}
+
+        {isPosting ? (
+          <View style={styles.statusRow}>
+            <ActivityIndicator color="#111827" size="small" />
+            <Text style={styles.statusLabel}>Submitting your remix…</Text>
+          </View>
+        ) : null}
+
+        {postError ? <Text style={styles.errorText}>{postError}</Text> : null}
+        {successMessage ? <Text style={styles.successText}>{successMessage}</Text> : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  content: {
+    padding: 24,
+    gap: 24,
+  },
+  pageTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+  },
+  pageSubtitle: {
+    fontSize: 16,
+    lineHeight: 22,
+    color: '#6b7280',
+  },
+  centeredState: {
+    alignItems: 'center',
+    gap: 12,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  statusLabel: {
+    fontSize: 14,
+    color: '#111827',
+  },
+  errorText: {
+    color: '#dc2626',
+    fontSize: 14,
+  },
+  successText: {
+    color: '#047857',
+    fontSize: 14,
+  },
+});

--- a/mused-rn/components/fragments/fragment-editor.tsx
+++ b/mused-rn/components/fragments/fragment-editor.tsx
@@ -17,6 +17,7 @@ export interface FragmentEditorProps {
   initialTitle?: string;
   originalFragmentId?: string | null;
   originalAuthorName?: string | null;
+  originalAuthorId?: string | null;
   onPostStart?: () => void;
   onPostSuccess?: (result: unknown) => void;
   onPostError?: (error: Error) => void;
@@ -42,6 +43,7 @@ const FragmentEditor: React.FC<FragmentEditorProps> = ({
   initialTitle = '',
   originalFragmentId = null,
   originalAuthorName = null,
+  originalAuthorId = null,
   onPostStart,
   onPostSuccess,
   onPostError,
@@ -103,24 +105,41 @@ const FragmentEditor: React.FC<FragmentEditorProps> = ({
     setIsPosting(true);
     setStatusMessage('Posting fragment...');
 
-    const padsPayload = pads
-      .filter((pad) => pad.sounds && pad.sounds.length > 0)
-      .map((pad) => ({
-        id: pad.id,
-        isActive: pad.isActive,
-        currentSoundIndex: pad.currentSoundIndex ?? 0,
-        sounds: pad.sounds.map((sound) => ({
-          soundId: sound.soundId,
-          soundName: sound.soundName,
-          soundUrl: sound.soundUrl,
-        })),
-      }));
+    const padsPayload = pads.map((pad, index) => ({
+      id: typeof pad.id === 'number' ? pad.id : index,
+      isActive: typeof pad.isActive === 'boolean' ? pad.isActive : pad.sounds.length > 0,
+      currentSoundIndex: typeof pad.currentSoundIndex === 'number' ? pad.currentSoundIndex : 0,
+      sounds: pad.sounds.map((sound, soundIndex) => ({
+        soundId: sound.soundId ?? `${index}-${soundIndex}`,
+        soundName: sound.soundName ?? 'Untitled sound',
+        soundUrl: sound.soundUrl,
+        downloadUrl: sound.downloadUrl,
+        source: sound.source,
+      })),
+    }));
+
+    const hasInvalidSoundSources = padsPayload.some((pad) =>
+      pad.sounds.some(
+        (sound) => typeof sound.soundUrl !== 'string' || !sound.soundUrl.startsWith('gs://'),
+      ),
+    );
+
+    if (hasInvalidSoundSources) {
+      const error = new Error(
+        'Some sounds are missing their storage references. Please reload the fragment and try again.',
+      );
+      setStatusMessage(error.message);
+      Alert.alert('Fragment incomplete', error.message);
+      onPostError?.(error);
+      return;
+    }
 
     const body = {
       pads: padsPayload,
       bpm,
       title: title?.trim() || 'Untitled Fragment',
       originalFragmentId: originalFragmentId ?? null,
+      originalAuthorId: originalAuthorId ?? null,
       columns: GRID_COLUMNS,
       rows: GRID_COLUMNS,
     };
@@ -166,6 +185,7 @@ const FragmentEditor: React.FC<FragmentEditorProps> = ({
     onPostStart,
     onPostSuccess,
     originalAuthorName,
+    originalAuthorId,
     originalFragmentId,
     pads,
     title,

--- a/mused-rn/components/fragments/fragment-editor.tsx
+++ b/mused-rn/components/fragments/fragment-editor.tsx
@@ -1,0 +1,337 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import type { Pad } from '@/lib/types';
+
+export interface FragmentEditorProps {
+  initialPads?: Pad[];
+  initialBpm?: number;
+  initialTitle?: string;
+  originalFragmentId?: string | null;
+  originalAuthorName?: string | null;
+  onPostStart?: () => void;
+  onPostSuccess?: (result: unknown) => void;
+  onPostError?: (error: Error) => void;
+}
+
+const GRID_COLUMNS = 4;
+const DEFAULT_PAD_COUNT = GRID_COLUMNS * GRID_COLUMNS;
+
+const createDefaultPads = (): Pad[] =>
+  Array.from({ length: DEFAULT_PAD_COUNT }, (_, index) => ({
+    id: index,
+    sounds: [],
+    isActive: false,
+    currentSoundIndex: 0,
+  }));
+
+const getApiUrl = () =>
+  process.env.EXPO_PUBLIC_MUSED_API_URL ?? process.env.NEXT_PUBLIC_MUSED_API_URL;
+
+const FragmentEditor: React.FC<FragmentEditorProps> = ({
+  initialPads,
+  initialBpm = 120,
+  initialTitle = '',
+  originalFragmentId = null,
+  originalAuthorName = null,
+  onPostStart,
+  onPostSuccess,
+  onPostError,
+}) => {
+  const [pads, setPads] = useState<Pad[]>(initialPads ?? createDefaultPads());
+  const [bpm, setBpm] = useState<number>(initialBpm);
+  const [title, setTitle] = useState<string>(initialTitle);
+  const [isPosting, setIsPosting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialPads) {
+      setPads(initialPads);
+    }
+  }, [initialPads]);
+
+  useEffect(() => {
+    setBpm(initialBpm);
+  }, [initialBpm]);
+
+  useEffect(() => {
+    setTitle(initialTitle);
+  }, [initialTitle]);
+
+  const hasAnySound = useMemo(
+    () => pads.some((pad) => pad.sounds && pad.sounds.length > 0),
+    [pads],
+  );
+
+  const handleBpmChange = useCallback((value: string) => {
+    const numeric = Number.parseInt(value, 10);
+    if (Number.isNaN(numeric)) {
+      setBpm(0);
+      return;
+    }
+    setBpm(Math.min(Math.max(numeric, 20), 240));
+  }, []);
+
+  const postFragment = useCallback(async () => {
+    if (isPosting) return;
+
+    if (!hasAnySound) {
+      const message = 'Add at least one sound to a pad before posting.';
+      setStatusMessage(message);
+      Alert.alert('Fragment incomplete', message);
+      return;
+    }
+
+    const apiUrl = getApiUrl();
+    if (!apiUrl) {
+      const error = new Error('API URL is not configured. Set EXPO_PUBLIC_MUSED_API_URL in your app config.');
+      setStatusMessage(error.message);
+      onPostError?.(error);
+      Alert.alert('Missing configuration', error.message);
+      return;
+    }
+
+    onPostStart?.();
+    setIsPosting(true);
+    setStatusMessage('Posting fragment...');
+
+    const padsPayload = pads
+      .filter((pad) => pad.sounds && pad.sounds.length > 0)
+      .map((pad) => ({
+        id: pad.id,
+        isActive: pad.isActive,
+        currentSoundIndex: pad.currentSoundIndex ?? 0,
+        sounds: pad.sounds.map((sound) => ({
+          soundId: sound.soundId,
+          soundName: sound.soundName,
+          soundUrl: sound.soundUrl,
+        })),
+      }));
+
+    const body = {
+      pads: padsPayload,
+      bpm,
+      title: title?.trim() || 'Untitled Fragment',
+      originalFragmentId: originalFragmentId ?? null,
+      columns: GRID_COLUMNS,
+      rows: GRID_COLUMNS,
+    };
+
+    try {
+      const response = await fetch(`${apiUrl}/fragments`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => null);
+        const errorMessage =
+          (errorPayload && (errorPayload.details || errorPayload.error)) ||
+          `Failed to post fragment (status ${response.status}).`;
+        throw new Error(errorMessage);
+      }
+
+      const result = await response.json().catch(() => null);
+
+      const successText = originalFragmentId
+        ? `Remix submitted! ${originalAuthorName ? `We'll let ${originalAuthorName} know.` : ''}`.trim()
+        : 'Fragment posted!';
+      setStatusMessage(successText);
+      Alert.alert('Success', successText);
+      onPostSuccess?.(result);
+    } catch (error) {
+      const normalisedError = error instanceof Error ? error : new Error('Could not post the fragment.');
+      setStatusMessage(normalisedError.message);
+      Alert.alert('Post failed', normalisedError.message);
+      onPostError?.(normalisedError);
+    } finally {
+      setIsPosting(false);
+    }
+  }, [
+    bpm,
+    hasAnySound,
+    isPosting,
+    onPostError,
+    onPostStart,
+    onPostSuccess,
+    originalAuthorName,
+    originalFragmentId,
+    pads,
+    title,
+  ]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.section}>
+        <Text style={styles.heading}>Fragment details</Text>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Title</Text>
+          <TextInput
+            accessibilityLabel="Fragment title"
+            autoCapitalize="sentences"
+            onChangeText={setTitle}
+            placeholder="Name your fragment"
+            style={styles.input}
+            value={title}
+          />
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>BPM</Text>
+          <TextInput
+            accessibilityLabel="Fragment tempo"
+            inputMode="numeric"
+            keyboardType="number-pad"
+            onChangeText={handleBpmChange}
+            placeholder="120"
+            style={styles.input}
+            value={bpm ? String(bpm) : ''}
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.heading}>Pads overview</Text>
+        <View style={styles.padGrid}>
+          {pads.map((pad) => {
+            const isFilled = pad.sounds.length > 0;
+            return (
+              <View
+                key={pad.id}
+                style={[styles.pad, isFilled ? styles.padFilled : styles.padEmpty]}
+                accessibilityLabel={`Pad ${pad.id + 1}, ${pad.sounds.length} sounds`}
+              >
+                <Text style={[styles.padTitle, isFilled ? styles.padTextOnFilled : null]}>
+                  Pad {pad.id + 1}
+                </Text>
+                <Text style={[styles.padSubtitle, isFilled ? styles.padMutedOnFilled : null]}>
+                  {pad.sounds.length} sound{pad.sounds.length === 1 ? '' : 's'}
+                </Text>
+                <Text style={[styles.padStatus, isFilled ? styles.padMutedOnFilled : null]}>
+                  {pad.isActive ? 'Active' : 'Inactive'}
+                </Text>
+              </View>
+            );
+          })}
+        </View>
+      </View>
+
+      {statusMessage ? <Text style={styles.statusMessage}>{statusMessage}</Text> : null}
+
+      <TouchableOpacity
+        accessibilityRole="button"
+        disabled={isPosting}
+        onPress={postFragment}
+        style={[styles.submitButton, isPosting ? styles.submitButtonDisabled : null]}
+      >
+        {isPosting ? <ActivityIndicator color="#ffffff" /> : <Text style={styles.submitLabel}>Post fragment</Text>}
+      </TouchableOpacity>
+      <Text style={styles.helperText}>Make sure at least one pad contains a sound before posting.</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 24,
+    paddingBottom: 32,
+  },
+  section: {
+    gap: 16,
+  },
+  heading: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  fieldGroup: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    opacity: 0.8,
+  },
+  input: {
+    borderColor: '#d0d0d0',
+    borderRadius: 12,
+    borderWidth: 1,
+    fontSize: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  padGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  pad: {
+    alignItems: 'flex-start',
+    borderRadius: 16,
+    flexBasis: '47%',
+    gap: 4,
+    padding: 16,
+  },
+  padFilled: {
+    backgroundColor: '#111827',
+  },
+  padEmpty: {
+    backgroundColor: '#f3f4f6',
+  },
+  padTitle: {
+    color: '#111827',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  padSubtitle: {
+    color: '#6b7280',
+    fontSize: 14,
+  },
+  padStatus: {
+    color: '#6b7280',
+    fontSize: 12,
+    fontStyle: 'italic',
+  },
+  padTextOnFilled: {
+    color: '#f9fafb',
+  },
+  padMutedOnFilled: {
+    color: '#d1d5db',
+  },
+  statusMessage: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  submitButton: {
+    alignItems: 'center',
+    backgroundColor: '#111827',
+    borderRadius: 999,
+    paddingHorizontal: 24,
+    paddingVertical: 14,
+  },
+  submitButtonDisabled: {
+    opacity: 0.6,
+  },
+  submitLabel: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  helperText: {
+    color: '#6b7280',
+    fontSize: 12,
+    textAlign: 'center',
+  },
+});
+
+export default FragmentEditor;

--- a/mused-rn/components/ui/icon-symbol.tsx
+++ b/mused-rn/components/ui/icon-symbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'plus.rectangle.fill': 'add-box',
 } as IconMapping;
 
 /**

--- a/mused-rn/lib/types.ts
+++ b/mused-rn/lib/types.ts
@@ -1,0 +1,39 @@
+export type SoundSource =
+  | 'prerecorded'
+  | 'live'
+  | 'uploaded'
+  | 'predefined'
+  | 'preset'
+  | 'marketplace'
+  | 'recorded';
+
+export interface PadSound {
+  soundId: string;
+  soundName: string;
+  soundUrl?: string;
+  downloadUrl?: string;
+  source?: SoundSource;
+  color?: string;
+}
+
+export interface Pad {
+  id: number;
+  sounds: PadSound[];
+  isActive: boolean;
+  currentSoundIndex?: number;
+}
+
+export interface Fragment {
+  id: string;
+  author: string;
+  pads: Pad[];
+  bpm?: number;
+  title?: string;
+  likes?: number;
+  comments?: unknown[];
+  originalAuthor?: string;
+  originalAuthorId?: string;
+  originalFragmentId?: string;
+  columns?: number;
+  rows?: number;
+}


### PR DESCRIPTION
## Summary
- add a fragment editor component for the Expo app that assembles pad data, posts to the API, and surfaces success or failure states
- create dedicated create and remix screens that wire the editor to loading/error indicators and register the remix stack route
- expose shared fragment types, hook the new create tab into the tab layout, and extend icon mappings for the new tab

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce3ac2c118832d9e34012d3b8be45f